### PR TITLE
すべての環境にbasic認証を導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == 'admin' && password == '1234'
+    end
+  end
 end


### PR DESCRIPTION
#what
アプリケーションにBasic認証を導入

#why
開発中に関係者以外が閲覧できないようにするため

