### PR TITLE
ログインボタンの表示

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,6 +1,8 @@
 .default_container
-  = render "shared/header"
-  
+  -if user_signed_in?
+    = render "shared/header"
+  -else
+    = render "shared/header-login"
   .body
     .slider
       .slider_box


### PR DESCRIPTION
# WHAT
ヘッダーにおいて、ログインしていないユーザーにログインボタンを表示する。ログイン済みユーザーにはマイページへのリンクを表示する。
#WHY
新規登録、ログインをトップページから行えるようにするため

ログイン前
https://gyazo.com/4c9b43a73d127956e8b81ff93bce1705
ログイン後はマイページボタンが表示される。
https://gyazo.com/e48b2808c2ea114eddd7e47cd55fe6f2