### PR TITLE
commodityページの見た目の修正

### DIFF
--- a/app/assets/stylesheets/_detail.scss
+++ b/app/assets/stylesheets/_detail.scss
@@ -49,51 +49,97 @@
         top: 18px;
         }
       }
-    .buy_space {
-      width: 700px;
-      height: 70px;
-      margin-top: 25px;
-      .buy_box {
-        font-weight: 500;
-        font-size: 20px;
-        height: 50px;
-        width :380px;
-        background: #DD0000;
-        color: white;
-        line-height: 47px;
-        text-align: center;
-        margin: auto;
-        a {
-          text-decoration: none;
-          color: white;
-          width: 380px;
-          height: 50px;
-        }
-         }
-      .des_box {
-        font-weight: 500;
-        font-size: 20px;
-        height: 50px;
-        width :380px;
-        background: #888888;
-        color: white;
-        line-height: 47px;
-        text-align: center;
-        margin: auto;
-        a {
-          text-decoration: none;
-          color: white;
+    // .buy_space {
+    //   width: 700px;
+    //   height: 70px;
+    //   margin-top: 25px;
+    //   .buy_box {
+    //     font-weight: 500;
+    //     font-size: 20px;
+    //     height: 50px;
+    //     width :380px;
+    //     background: #DD0000;
+    //     color: white;
+    //     line-height: 47px;
+    //     text-align: center;
+    //     margin: auto;
+    //     a {
+    //       text-decoration: none;
+    //       color: white;
+    //       width: 380px;
+    //       height: 50px;
+    //     }
+    //      }
+    //   .des_box {
+    //     font-weight: 500;
+    //     font-size: 20px;
+    //     height: 50px;
+    //     width :380px;
+    //     background: #888888;
+    //     color: white;
+    //     line-height: 47px;
+    //     text-align: center;
+    //     margin: auto;
+    //     a {
+    //       text-decoration: none;
+    //       color: white;
           
-        }
-      }   
-      }
-    .description {
-      font-size: 20px;
-      padding: 20px 20px 20px 20px;
-      width: 660px;
-      height: 200px;
+    //     }
+    //   }   
+    //   }
+    // .description {
+    //   font-size: 20px;
+    //   padding: 20px 20px 20px 20px;
+    //   width: 660px;
+    //   height: 200px;
       
-    }    
+    // }    
    }
 }
+.item_container{
+  
+  .buy_space {
+    background-color: #fff;
+    width: 668px;
+    margin: 25px auto;
+    padding: 24px 16px;
+    .buy_box {
+      font-weight: 500;
+      font-size: 20px;
+      // height: 50px;
+      // width :380px;
+      background: #DD0000;
+      color: white;
+      line-height: 47px;
+      text-align: center;
+      margin: auto;
+      a {
+        text-decoration: none;
+        color: white;
+      }
+      }
+    .des_box {
+      font-weight: 500;
+      font-size: 20px;
+      // height: 50px;
+      // width :380px;
+      background: #888888;
+      color: white;
+      line-height: 47px;
+      text-align: center;
+      margin: auto;
+      margin-top: 30px;
+      a {
+        text-decoration: none;
+        color: white;
+        
+      }
+    }   
+    }
+}
 
+.description {
+  font-size: 20px;
+  padding-top: 32px;
+  width: 620px;
+} 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -34,22 +34,6 @@
         .new_item_button__content
           %p 出品
           = fa_icon "camera"
-    .aside
-      .aside__body
-        .aside__body__menu
-          .right_group
-            .group_upper
-              スマホでかんたんフリマアプリ
-            .group_lower
-              今すぐ無料ダウンロード！
-            .logo
-              = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/mercari_icon-f75780e32e41e052c8aaa8b446331cd8.png', class: "logo-img"
-              %a
-                = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/app-store-a5c17948c6fd6d5b60b13d421cd60b35.svg', class: "app-img"
-              %a
-                = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/google-play-495575abb895b405aa6336b2a4304958.svg', class: "google-img"
-          .figure
-            = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/download_app_pc-a4418175e8be071827ac88d073f40e4a.png', class: "figure_img"
 
   = render "shared/footer"
   

--- a/app/views/mypages/commodity.html.haml
+++ b/app/views/mypages/commodity.html.haml
@@ -1,49 +1,100 @@
-
-.default_container
-  = render "shared/header"
-  .back
-    .head_space
-    .details_box
-      .name
+-# .default_container
+-#   = render "shared/header"
+-#   .back
+-#     .head_space
+-#     .details_box
+-#       .name
+-#         #{@item.name}
+-#       .image  
+-#         #{@item.image}
+-#       .data
+-#         %table{:border => ""}
+-#           %tr
+-#             %td
+-#               カテゴリー
+-#             %td #{@item.category}
+-#           %tr
+-#             %td
+-#               ブランド
+-#             %td #{@item.brand}
+-#           %tr
+-#             %td
+-#               商品の状態
+-#             %td #{@item.status}
+-#           %tr
+-#             %td
+-#               配送料の負担
+-#             %td  #{@item.cost}
+-#           %tr
+-#             %td
+-#               配送源の地域
+-#             %td #{@item.area}
+-#       .price
+-#         ¥#{@item.price}
+-#         .unit
+-#           (税込)送料込み
+.wrap
+  .default_container
+    = render "shared/header"
+    .item-box
+      .item-box--name
         #{@item.name}
-      .image  
-        #{@item.image}
-      .data
-        %table{:border => ""}
-          %tr
-            %td
-              カテゴリー
-            %td #{@item.category}
-          %tr
-            %td
-              ブランド
-            %td #{@item.brand}
-          %tr
-            %td
-              商品の状態
-            %td #{@item.status}
-          %tr
-            %td
-              配送料の負担
-            %td  #{@item.cost}
-          %tr
-            %td
-              配送源の地域
-            %td #{@item.area}
-      .price
-        ¥#{@item.price}   
-        .unit
-          (税込)送料込み
+      .item-box--content.clearfix
+        .photos
+          %ul.photos--main
+            - @item.images.each_with_index do |image, i|
+              %li.photos--main__piece
+                = image_tag @item.images[i].variant(resize:'300x300',auto_orient: true)
+          %ul.photos--thumb
+            - @item.images.each_with_index do |image, i|
+              %li.photos--thumb__piece
+                = image_tag @item.images[i].variant(resize:'60x60',auto_orient: true)
+        %table.item-detail-table
+          %tbody
+            %tr
+              %th.left 出品者
+              %td.right #{@item.user.nickname}
+            %tr
+              %th.left カテゴリー
+              %td.right #{@item.category}
+            %tr
+              %th.left
+                ブランド
+              %td.right #{@item.brand}
+            %tr
+              %th.left 商品のサイズ
+              %td.right
+            %tr
+              %th.left
+                商品の状態
+              %td.right #{@item.status}
+            %tr
+              %th.left
+                配送料の負担
+              %td.right  #{@item.cost}
+            %tr
+              %th.left 配送の方法
+              %td.right
+                ゆうゆうメルカリ便
+            %tr
+              %th.left
+                配送元の地域
+              %td.right #{@item.area}
+            %tr
+              %th.left 発送日の目安
+              %td.right
+      .item-box--price
+        %span.item-box--price__bold
+          ¥#{@item.price}
+        %span.item-box--price__tax (税込)
+        %span.item-box--price__fee 送料込み
+      .description
+        #{@item.description}
+    .item_container
       .buy_space
         .buy_box
           = link_to "商品の編集", "/items/#{@item.id}/edit"
         .des_box
-          = link_to '削除', "/items/#{@item.id}", method: :delete, data: {confirm: '本当に削除しますか？'}
-  
-            
-      .description
-        #{@item.description}         
+          = link_to 'この商品を削除する', "/items/#{@item.id}", method: :delete, data: {confirm: '本当に削除しますか？'}
 
-
-          
-
+  = render "shared/footer"

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,3 +1,20 @@
+.aside
+  .aside__body
+    .aside__body__menu
+      .right_group
+        .group_upper
+          スマホでかんたんフリマアプリ
+        .group_lower
+          今すぐ無料ダウンロード！
+        .logo
+          = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/mercari_icon-f75780e32e41e052c8aaa8b446331cd8.png', class: "logo-img"
+          %a
+            = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/app-store-a5c17948c6fd6d5b60b13d421cd60b35.svg', class: "app-img"
+          %a
+            = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/google-play-495575abb895b405aa6336b2a4304958.svg', class: "google-img"
+      .figure
+        = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/download_app_pc-a4418175e8be071827ac88d073f40e4a.png', class: "figure_img"
+
 .footer
   .nav.clearfix
     .footer-cell


### PR DESCRIPTION
#what
マイページから飛ぶ商品情報ページ（commodityページ）の見た目の修正。
scssの調整、jsの適用、それに伴うhamlの修正。
およびページ下段にあるaside部分をテンプレート化し_footer.html.hamlに統合。
#why
デザインが大幅に実装されていない状態を解決するため。
本番環境で確認中に発見し、アプリのデザインに統一性を持たせるため。