### PR TITLE
create-item-delete-btn

### DIFF
--- a/app/views/shared/_edit-btn.html.haml
+++ b/app/views/shared/_edit-btn.html.haml
@@ -1,2 +1,4 @@
 .edit-btn
   = link_to "商品を編集する", edit_item_path
+.edit-btn
+  = link_to 'この商品を削除する', item_path, method: :delete, data: {confirm: '本当に削除しますか？'}


### PR DESCRIPTION
# WHAT
- 商品詳細ページに削除ボタンを設置。

# WHY
- 商品詳細ページから出品者が商品の出品をとりやめられるようにするため