### PR TITLE
値段部分の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,9 +8,6 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    # このまま導入するとunknown attribute 'item_id' for Image.というエラーが発生してしまう
-    # @parents = Category.all.order("id ASC").limit(10) ←全く同じコードをcategoriesコントローラーへ記載
-
   end
 
   def buy
@@ -24,8 +21,6 @@ class ItemsController < ApplicationController
 
   
   def create
-    # formのデータを受け取る
-    # binding.pry
     @item = Item.new(item_params)
     if @item.save
       redirect_to items_path, notice: '出品が完了しました'
@@ -35,6 +30,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   def update

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -115,7 +115,7 @@
                         .l-right.sell-price-input
                           ¥
                           %div
-                            =f.number_field :price, class: "input-default", id: "jsNum", placeholder: "例）300", value: ""
+                            =f.number_field :price, class: "input-default", id: "jsNum", placeholder: "例）300", value: "#{@item.price}"
                     %li.clearfix
                       %div
                         .l-left


### PR DESCRIPTION
#what
編集ページにおける値段フォームにデフォルトの価格を入れる。
#why
デフォルトの価格が入っていないと、新たに入力しなければならない状態の改善のため。